### PR TITLE
Sync w/ updated cli-extras

### DIFF
--- a/cli-nix.cabal
+++ b/cli-nix.cabal
@@ -20,7 +20,7 @@ library
   default-language: Haskell2010
   build-depends:
       base            >=4.12    && <4.15
-    , cli-extras      >=0.1.0.0 && <0.2
+    , cli-extras      >=0.2.0.0 && <0.3
     , data-default    >=0.7.1.1 && <0.8
     , exceptions      >=0.10.3  && <0.11
     , lens            >=4.17.1  && <4.20

--- a/cli-nix.cabal
+++ b/cli-nix.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               cli-nix
-version:            0.1.0.1
+version:            0.1.1.0
 license:            BSD3
 license-file:       LICENSE
 copyright:          Obsidian Systems LLC 2020
@@ -20,7 +20,7 @@ library
   default-language: Haskell2010
   build-depends:
       base            >=4.12    && <4.15
-    , cli-extras      >=0.2.0.0 && <0.3
+    , cli-extras      >=0.2     && <0.3
     , data-default    >=0.7.1.1 && <0.8
     , exceptions      >=0.10.3  && <0.11
     , lens            >=4.17.1  && <4.20

--- a/dep/cli-extras/default.nix
+++ b/dep/cli-extras/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/cli-extras/github.json
+++ b/dep/cli-extras/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "cli-extras",
+  "branch": "master",
+  "private": false,
+  "rev": "6c187ef2abf9973d3fb4c59608f7cd7d83ef14c1",
+  "sha256": "1jizqa018ls214l2ka1dwcw1nws6398360pw39vsngah00vp74cd"
+}

--- a/dep/cli-extras/thunk.nix
+++ b/dep/cli-extras/thunk.nix
@@ -2,7 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
+  } else (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/cli-extras/thunk.nix
+++ b/dep/cli-extras/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/release.nix
+++ b/release.nix
@@ -10,12 +10,7 @@ let
       ver = "0.2";
       sha256 = "1g795yq36n7c6ycs7c0799c3cw78ad0cya6lj4x08m0xnfx98znn";
     } {};
-    cli-extras = self.callCabal2nix "cli-extras" (nixos2003.fetchFromGitHub {
-      owner = "obsidiansystems";
-      repo = "cli-extras";
-      rev = "d43786fc6c5856e5f47d7f66c110853adc87dc0f";
-      sha256 = sha256:jZFzNwBQPat3GvwCM1AaRnMbOOMtqCkoCUJTFIDCP8o=;
-    }) {};
+    cli-extras = self.callCabal2nix "cli-extras" (import ./dep/cli-extras/thunk.nix) {};
   };
   ghcs = rec {
     ghc865 = nixos2003.haskell.packages.ghc865.override {

--- a/release.nix
+++ b/release.nix
@@ -10,11 +10,12 @@ let
       ver = "0.2";
       sha256 = "1g795yq36n7c6ycs7c0799c3cw78ad0cya6lj4x08m0xnfx98znn";
     } {};
-    cli-extras = self.callHackageDirect {
-      pkg = "cli-extras";
-      ver = "0.1.0.1";
-      sha256 = "1hnmk8jm9zrhcv8vz9raj0p26svc0rd47zc7nz58sja6jsakcaq2";
-    } {};
+    cli-extras = self.callCabal2nix "cli-extras" (nixos2003.fetchFromGitHub {
+      owner = "obsidiansystems";
+      repo = "cli-extras";
+      rev = "7a81d23776a1b992005cb74b2934992e03582670";
+      sha256 = sha256:iSo88gSAFkkBf6b1rswF0y/Wd/NeDff9O39L6S7QdgM=;
+    }) {};
   };
   ghcs = rec {
     ghc865 = nixos2003.haskell.packages.ghc865.override {

--- a/release.nix
+++ b/release.nix
@@ -13,8 +13,8 @@ let
     cli-extras = self.callCabal2nix "cli-extras" (nixos2003.fetchFromGitHub {
       owner = "obsidiansystems";
       repo = "cli-extras";
-      rev = "7a81d23776a1b992005cb74b2934992e03582670";
-      sha256 = sha256:iSo88gSAFkkBf6b1rswF0y/Wd/NeDff9O39L6S7QdgM=;
+      rev = "d43786fc6c5856e5f47d7f66c110853adc87dc0f";
+      sha256 = sha256:jZFzNwBQPat3GvwCM1AaRnMbOOMtqCkoCUJTFIDCP8o=;
     }) {};
   };
   ghcs = rec {

--- a/src/Bindings/Cli/Nix.hs
+++ b/src/Bindings/Cli/Nix.hs
@@ -214,7 +214,7 @@ nixCmd
   :: ( MonadIO m
      , MonadMask m
      , MonadLog Output m
-     , HasCliConfig m
+     , HasCliConfig e m
      , MonadError e m
      , AsProcessFailure e
      , MonadFail m


### PR DESCRIPTION
Looks like the only breaking change was adding the `e` parameter to `HasCliConfig`, but I'd like to see what CI thinks of it. I updated the `release.nix` to point to the right commit of `cli-extras` to make sure stuff builds.
Checked w/ ghci and `cabal build`.